### PR TITLE
Escape key closes help window

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build and check with Gradle (Ubuntu)
         if: runner.os == 'Linux'
-        run: ./gradlew check coverage
+        run: xvfb-run ./gradlew check coverage
 
       - name: Build and check with Gradle (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build and check with Gradle (Ubuntu)
         if: runner.os == 'Linux'
-        run: xvfb-run ./gradlew check coverage
+        run: ./gradlew check coverage
 
       - name: Build and check with Gradle (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,15 +36,15 @@ jobs:
           java-package: jdk+fx
 
       - name: Build and check with Gradle (Ubuntu)
-        if: matrix.platform == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest'
         run: xvfb-run ./gradlew check coverage
 
       - name: Build and check with Gradle (macOS)
-        if: matrix.platform == 'macos-latest'
+        if: matrix.os == 'macos-latest'
         run: ./gradlew check coverage
 
       - name: Build and check with Gradle (Windows)
-        if: matrix.platform == 'windows-latest'
+        if: matrix.os == 'windows-latest'
         run: ./gradlew check coverage
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,7 +35,16 @@ jobs:
           java-version: '11'
           java-package: jdk+fx
 
-      - name: Build and check with Gradle
+      - name: Build and check with Gradle (Ubuntu)
+        if: matrix.platform == 'ubuntu-latest'
+        run: xvfb-run ./gradlew check coverage
+
+      - name: Build and check with Gradle (macOS)
+        if: matrix.platform == 'macos-latest'
+        run: ./gradlew check coverage
+
+      - name: Build and check with Gradle (Windows)
+        if: matrix.platform == 'windows-latest'
         run: ./gradlew check coverage
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,15 +36,15 @@ jobs:
           java-package: jdk+fx
 
       - name: Build and check with Gradle (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         run: xvfb-run ./gradlew check coverage
 
       - name: Build and check with Gradle (macOS)
-        if: matrix.os == 'macos-latest'
+        if: runner.os == 'macOS'
         run: ./gradlew check coverage
 
       - name: Build and check with Gradle (Windows)
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         run: ./gradlew check coverage
 
       - name: Upload coverage reports to Codecov

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ check.dependsOn javadoc
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport
+    systemProperties = ['testfx.robot': 'glass']
 }
 
 task coverage(type: JacocoReport) {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ task coverage(type: JacocoReport) {
 }
 
 dependencies {
+    String testFxVersion = "4.0.18"
     String jUnitVersion = '5.4.0'
     String javaFxVersion = '17.0.7'
 
@@ -62,7 +63,9 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'
 
+    testImplementation group: 'org.testfx', name: 'testfx-junit5', version: testFxVersion
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
+    testImplementation group: 'org.testfx', name: 'openjfx-monocle', version: 'jdk-12.0.1+2'
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
 }

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -68,12 +68,17 @@ NUSContacts is a **desktop app for managing contacts, optimized for use via a Co
 
 ### Viewing help : `help`
 
-Shows a message explaning how to access the help page.
-
-![help message](images/helpMessage.png)
+Shows a message listing out all the available commands and their purpose.
 
 Format: `help`
 
+For more information regarding the comamnd formats and examples, press `F1` to open up a help window (as shown in the picture below).
+To close the help window, you can simply press `esc` on your keyboard (other methods such as `alt`+`F4` and clicking on 
+the red `X` button on the top right corner of the window also works).
+
+![help message](images/helpMessage.png)
+
+The project website includes the NUSContacts user guide, which contains a more detailed description of each command.
 
 ### Adding a person: `add`
 

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -7,6 +7,8 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
@@ -36,6 +38,15 @@ public class HelpWindow extends UiPart<Stage> {
     public HelpWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
+
+        // Pressing ESC key while this window is in focus will close it.
+        root.addEventHandler(
+            KeyEvent.KEY_PRESSED,
+            event -> {
+                if (event.getCode() == KeyCode.ESCAPE) {
+                    getRoot().close();
+                }
+            });
     }
 
     /**
@@ -87,6 +98,7 @@ public class HelpWindow extends UiPart<Stage> {
      * Focuses on the help window.
      */
     public void focus() {
+        getRoot().setIconified(false);
         getRoot().requestFocus();
     }
 

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -9,6 +9,7 @@ import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 
+import javafx.application.Platform;
 import javafx.scene.input.KeyCode;
 import javafx.stage.Stage;
 
@@ -25,17 +26,29 @@ public class HelpWindowTest {
 
     @Test
     public void closeOnEscapeKeyPress(FxRobot robot) {
-        robot.press(KeyCode.ESCAPE);
-        assertFalse(helpWindow.isShowing());
+        Platform.runLater(() -> helpWindow.show());
+        try {
+            Thread.sleep(2000);
+            robot.press(KeyCode.ESCAPE);
+            assertFalse(helpWindow.isShowing());
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     @Test
     public void remainOpenOnNonEscapeKeyPress(FxRobot robot) {
-        robot.press(KeyCode.A);
-        robot.press(KeyCode.SOFTKEY_0);
-        robot.press(KeyCode.L);
-        robot.press(KeyCode.BACK_SPACE);
-        robot.press(KeyCode.DELETE);
-        assertTrue(helpWindow.isShowing());
+        Platform.runLater(() -> helpWindow.show());
+        try {
+            Thread.sleep(2000);
+            robot.press(KeyCode.A);
+            robot.press(KeyCode.SOFTKEY_0);
+            robot.press(KeyCode.L);
+            robot.press(KeyCode.BACK_SPACE);
+            robot.press(KeyCode.DELETE);
+            assertTrue(helpWindow.isShowing());
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -3,6 +3,8 @@ package seedu.address.ui;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testfx.api.FxRobot;
@@ -24,6 +26,7 @@ public class HelpWindowTest {
         helpWindow.show();
     }
 
+    @DisabledOnOs(OS.LINUX)
     @Test
     public void closeOnEscapeKeyPress(FxRobot robot) {
         Platform.runLater(() -> {

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -28,10 +28,10 @@ public class HelpWindowTest {
     @Test
     public void closeOnEscapeKeyPress(FxRobot robot) throws Exception {
         Platform.runLater(() -> helpWindow.focus());
-        WaitForAsyncUtils.waitForFxEvents();
+        WaitForAsyncUtils.waitForFxEvents(); // Wait for help window to be focused.
+
         robot.press(KeyCode.ESCAPE);
-        WaitForAsyncUtils.waitForFxEvents();
-        Thread.sleep(2000); // Buffer time for key press to register and close window.
+        WaitForAsyncUtils.waitForFxEvents(); // Wait for any new events in javaFx to be completed.
         assertFalse(helpWindow.isShowing());
     }
 
@@ -43,14 +43,14 @@ public class HelpWindowTest {
         robot.press(KeyCode.BACK_SPACE);
         robot.press(KeyCode.DELETE);
 
-        Thread.sleep(2000); // Buffer time for key press to register.
+        WaitForAsyncUtils.waitForFxEvents(); // Wait for any new events in javaFx to be completed.
         assertTrue(helpWindow.isShowing());
     }
 
     @Test
     public void focusCall() throws Exception {
         Platform.runLater(() -> helpWindow.focus());
-        Thread.sleep(2000);
+        WaitForAsyncUtils.waitForFxEvents(); // Wait for any new events in javaFx to be completed.
         assertTrue(helpWindow.isShowing());
     }
 }

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -25,43 +25,30 @@ public class HelpWindowTest {
     }
 
     @Test
-    public void closeOnEscapeKeyPress(FxRobot robot) {
-        try {
-            assertTrue(helpWindow.isShowing());
-            robot.press(KeyCode.ESCAPE);
+    public void closeOnEscapeKeyPress(FxRobot robot) throws Exception {
+        assertTrue(helpWindow.isShowing());
+        robot.press(KeyCode.ESCAPE);
 
-            Thread.sleep(2000); // Buffer time for key press to register and close window.
-            assertFalse(helpWindow.isShowing());
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        Thread.sleep(2000); // Buffer time for key press to register and close window.
+        assertFalse(helpWindow.isShowing());
     }
 
     @Test
-    public void remainOpenOnNonEscapeKeyPress(FxRobot robot) {
-        try {
-            robot.press(KeyCode.A);
-            robot.press(KeyCode.SOFTKEY_0);
-            robot.press(KeyCode.L);
-            robot.press(KeyCode.BACK_SPACE);
-            robot.press(KeyCode.DELETE);
+    public void remainOpenOnNonEscapeKeyPress(FxRobot robot) throws Exception {
+        robot.press(KeyCode.A);
+        robot.press(KeyCode.SOFTKEY_0);
+        robot.press(KeyCode.L);
+        robot.press(KeyCode.BACK_SPACE);
+        robot.press(KeyCode.DELETE);
 
-            Thread.sleep(2000); // Buffer time for key press to register.
-            assertTrue(helpWindow.isShowing());
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        Thread.sleep(2000); // Buffer time for key press to register.
+        assertTrue(helpWindow.isShowing());
     }
 
     @Test
-    public void focusCall() {
+    public void focusCall() throws Exception {
         Platform.runLater(() -> helpWindow.focus());
-
-        try {
-            Thread.sleep(2000);
-            assertTrue(helpWindow.isShowing());
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        Thread.sleep(2000);
+        assertTrue(helpWindow.isShowing());
     }
 }

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -27,6 +27,7 @@ public class HelpWindowTest {
 
     @Test
     public void closeOnEscapeKeyPress(FxRobot robot) throws Exception {
+        helpWindow.focus();
         robot.press(KeyCode.ESCAPE);
         WaitForAsyncUtils.waitForFxEvents();
         Thread.sleep(2000); // Buffer time for key press to register and close window.

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -26,7 +26,6 @@ public class HelpWindowTest {
 
     @Test
     public void closeOnEscapeKeyPress(FxRobot robot) throws Exception {
-        assertTrue(helpWindow.isShowing());
         robot.press(KeyCode.ESCAPE);
 
         Thread.sleep(2000); // Buffer time for key press to register and close window.

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -22,13 +22,13 @@ public class HelpWindowTest {
     @Start
     public void start(Stage stage) {
         helpWindow = new HelpWindow(stage);
-        Platform.runLater(() -> helpWindow.show());
-        WaitForAsyncUtils.waitForFxEvents();
+        helpWindow.show();
     }
 
     @Test
     public void closeOnEscapeKeyPress(FxRobot robot) throws Exception {
-        helpWindow.focus();
+        Platform.runLater(() -> helpWindow.focus());
+        WaitForAsyncUtils.waitForFxEvents();
         robot.press(KeyCode.ESCAPE);
         WaitForAsyncUtils.waitForFxEvents();
         Thread.sleep(2000); // Buffer time for key press to register and close window.

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -1,0 +1,41 @@
+package seedu.address.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+
+import javafx.scene.input.KeyCode;
+import javafx.stage.Stage;
+
+@ExtendWith(ApplicationExtension.class)
+public class HelpWindowTest {
+
+    private HelpWindow helpWindow;
+
+    @Start
+    public void start(Stage stage) {
+        helpWindow = new HelpWindow(stage);
+        helpWindow.show();
+    }
+
+    @Test
+    public void closeOnEscapeKeyPress(FxRobot robot) {
+        robot.press(KeyCode.ESCAPE);
+        assertFalse(helpWindow.isShowing());
+    }
+
+    @Test
+    public void remainOpenOnNonEscapeKeyPress(FxRobot robot) {
+        robot.press(KeyCode.A);
+        robot.press(KeyCode.SOFTKEY_0);
+        robot.press(KeyCode.L);
+        robot.press(KeyCode.BACK_SPACE);
+        robot.press(KeyCode.DELETE);
+        assertTrue(helpWindow.isShowing());
+    }
+}

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -22,7 +22,8 @@ public class HelpWindowTest {
     @Start
     public void start(Stage stage) {
         helpWindow = new HelpWindow(stage);
-        helpWindow.show();
+        Platform.runLater(() -> helpWindow.show());
+        WaitForAsyncUtils.waitForFxEvents();
     }
 
     @Test

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -11,7 +11,6 @@ import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 
-import javafx.application.Platform;
 import javafx.scene.input.KeyCode;
 import javafx.stage.Stage;
 
@@ -29,35 +28,18 @@ public class HelpWindowTest {
     @DisabledOnOs(OS.LINUX)
     @Test
     public void closeOnEscapeKeyPress(FxRobot robot) {
-        Platform.runLater(() -> {
-            helpWindow.show();
-            robot.press(KeyCode.ESCAPE);
-        });
-
-        try {
-            Thread.sleep(2000);
-            assertFalse(helpWindow.isShowing());
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        assertTrue(helpWindow.isShowing());
+        robot.press(KeyCode.ESCAPE);
+        assertFalse(helpWindow.isShowing());
     }
 
     @Test
     public void remainOpenOnNonEscapeKeyPress(FxRobot robot) {
-        Platform.runLater(() -> {
-            helpWindow.show();
-            robot.press(KeyCode.A);
-            robot.press(KeyCode.SOFTKEY_0);
-            robot.press(KeyCode.L);
-            robot.press(KeyCode.BACK_SPACE);
-            robot.press(KeyCode.DELETE);
-        });
-
-        try {
-            Thread.sleep(2000);
-            assertTrue(helpWindow.isShowing());
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        robot.press(KeyCode.A);
+        robot.press(KeyCode.SOFTKEY_0);
+        robot.press(KeyCode.L);
+        robot.press(KeyCode.BACK_SPACE);
+        robot.press(KeyCode.DELETE);
+        assertTrue(helpWindow.isShowing());
     }
 }

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -11,6 +11,7 @@ import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
 
+import javafx.application.Platform;
 import javafx.scene.input.KeyCode;
 import javafx.stage.Stage;
 
@@ -41,5 +42,17 @@ public class HelpWindowTest {
         robot.press(KeyCode.BACK_SPACE);
         robot.press(KeyCode.DELETE);
         assertTrue(helpWindow.isShowing());
+    }
+
+    @Test
+    public void focusCall() {
+        Platform.runLater(() -> helpWindow.focus());
+
+        try {
+            Thread.sleep(2000);
+            assertTrue(helpWindow.isShowing());
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
@@ -26,22 +24,33 @@ public class HelpWindowTest {
         helpWindow.show();
     }
 
-    @DisabledOnOs(OS.LINUX)
     @Test
     public void closeOnEscapeKeyPress(FxRobot robot) {
-        assertTrue(helpWindow.isShowing());
-        robot.press(KeyCode.ESCAPE);
-        assertFalse(helpWindow.isShowing());
+        try {
+            assertTrue(helpWindow.isShowing());
+            robot.press(KeyCode.ESCAPE);
+
+            Thread.sleep(2000); // Buffer time for key press to register and close window.
+            assertFalse(helpWindow.isShowing());
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     @Test
     public void remainOpenOnNonEscapeKeyPress(FxRobot robot) {
-        robot.press(KeyCode.A);
-        robot.press(KeyCode.SOFTKEY_0);
-        robot.press(KeyCode.L);
-        robot.press(KeyCode.BACK_SPACE);
-        robot.press(KeyCode.DELETE);
-        assertTrue(helpWindow.isShowing());
+        try {
+            robot.press(KeyCode.A);
+            robot.press(KeyCode.SOFTKEY_0);
+            robot.press(KeyCode.L);
+            robot.press(KeyCode.BACK_SPACE);
+            robot.press(KeyCode.DELETE);
+
+            Thread.sleep(2000); // Buffer time for key press to register.
+            assertTrue(helpWindow.isShowing());
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     @Test

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -26,10 +26,13 @@ public class HelpWindowTest {
 
     @Test
     public void closeOnEscapeKeyPress(FxRobot robot) {
-        Platform.runLater(() -> helpWindow.show());
+        Platform.runLater(() -> {
+            helpWindow.show();
+            robot.press(KeyCode.ESCAPE);
+        });
+
         try {
             Thread.sleep(2000);
-            robot.press(KeyCode.ESCAPE);
             assertFalse(helpWindow.isShowing());
         } catch (InterruptedException e) {
             e.printStackTrace();
@@ -38,14 +41,17 @@ public class HelpWindowTest {
 
     @Test
     public void remainOpenOnNonEscapeKeyPress(FxRobot robot) {
-        Platform.runLater(() -> helpWindow.show());
-        try {
-            Thread.sleep(2000);
+        Platform.runLater(() -> {
+            helpWindow.show();
             robot.press(KeyCode.A);
             robot.press(KeyCode.SOFTKEY_0);
             robot.press(KeyCode.L);
             robot.press(KeyCode.BACK_SPACE);
             robot.press(KeyCode.DELETE);
+        });
+
+        try {
+            Thread.sleep(2000);
             assertTrue(helpWindow.isShowing());
         } catch (InterruptedException e) {
             e.printStackTrace();

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
 
 import javafx.application.Platform;
 import javafx.scene.input.KeyCode;
@@ -27,7 +28,7 @@ public class HelpWindowTest {
     @Test
     public void closeOnEscapeKeyPress(FxRobot robot) throws Exception {
         robot.press(KeyCode.ESCAPE);
-
+        WaitForAsyncUtils.waitForFxEvents();
         Thread.sleep(2000); // Buffer time for key press to register and close window.
         assertFalse(helpWindow.isShowing());
     }

--- a/src/test/java/seedu/address/ui/HelpWindowTest.java
+++ b/src/test/java/seedu/address/ui/HelpWindowTest.java
@@ -3,9 +3,9 @@ package seedu.address.ui;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;


### PR DESCRIPTION
Previously, minimizing the help window will cause the help command (and help button) to not work and the window will remain minimized. I added the `setIconified` line in `focus` function to un-minimize the window.

Closes #85 