### PR TITLE
Add Undo command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -66,6 +66,7 @@ public class AddCommand extends Command {
             throw new CommandExecutionException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        model.saveAddressBook(); // Save previous copy of address book if command execution successful.
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -18,6 +18,7 @@ public class ClearCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        model.saveAddressBook(); // Save previous copy of address book if command execution successful.
         model.setAddressBook(new AddressBook());
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -64,6 +64,7 @@ public class DeleteCommand extends Command {
             peopleToDelete[i] = personToDelete;
         }
 
+        model.saveAddressBook(); // Save previous copy of address book if command execution successful.
         String resultMessage = "";
 
         // Delete the people from model.

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -92,6 +92,7 @@ public class EditCommand extends Command {
             throw new CommandExecutionException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        model.saveAddressBook(); // Save previous copy of address book if command execution successful.
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -20,6 +20,7 @@ public class HelpCommand extends Command {
             + "5. " + DeleteCommand.COMMAND_DESCRIPTION
             + "6. " + ClearCommand.COMMAND_DESCRIPTION
             + "7. " + ExitCommand.COMMAND_DESCRIPTION
+            + "8. " + UndoCommand.COMMAND_DESCRIPTION
             + "For more detailed information on each command, please press F1 to refer to the project website.";
 
 

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.exceptions.CommandExecutionException;
+import seedu.address.model.Model;
+
+/**
+ * Undo the state of the address book if there was any new changes to it.
+ */
+public class UndoCommand extends Command {
+    public static final String COMMAND_WORD = "undo";
+
+    public static final String COMMAND_DESCRIPTION = COMMAND_WORD
+            + ": Undo the changes (if any) made by the previous command execution.\n";
+
+    public static final String MESSAGE_SUCCESS = "Successfully revert the changes.";
+
+    public static final String MESSAGE_NO_PREVIOUS_STATE = "No new changes has been made to the data.";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandExecutionException {
+        requireNonNull(model);
+
+        try {
+            model.undoAddressBook();
+        } catch (NullPointerException e) {
+            throw new CommandExecutionException(MESSAGE_NO_PREVIOUS_STATE);
+        }
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -46,6 +47,7 @@ public class AddressBookParser {
         ListCommand.COMMAND_WORD,
         ExitCommand.COMMAND_WORD,
         HelpCommand.COMMAND_WORD,
+        UndoCommand.COMMAND_WORD
     };
 
     /**
@@ -111,6 +113,10 @@ public class AddressBookParser {
         case HelpCommand.COMMAND_WORD:
             ensureNoArgument(command, arguments);
             return new HelpCommand();
+
+        case UndoCommand.COMMAND_WORD:
+            ensureNoArgument(command, arguments);
+            return new UndoCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -96,6 +96,14 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     //// util methods
 
+    /**
+     * Creates a new copy of the current {@code AddressBook}.
+     * @return The new copy of the AddressBook.
+     */
+    public AddressBook copy() {
+        return new AddressBook(this);
+    }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -52,6 +52,12 @@ public interface Model {
     /** Returns the AddressBook */
     ReadOnlyAddressBook getAddressBook();
 
+    /** Save a copy of address book. */
+    void saveAddressBook();
+
+    /** Replaces the current addressbook with the previous one. */
+    void undoAddressBook();
+
     /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -23,6 +23,8 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
 
+    private AddressBook previousAddressBook;
+
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
@@ -31,6 +33,7 @@ public class ModelManager implements Model {
 
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
+        this.previousAddressBook = null;
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
@@ -85,6 +88,17 @@ public class ModelManager implements Model {
     @Override
     public ReadOnlyAddressBook getAddressBook() {
         return addressBook;
+    }
+
+    @Override
+    public void saveAddressBook() {
+        previousAddressBook = addressBook.copy();
+    }
+
+    @Override
+    public void undoAddressBook() {
+        addressBook.resetData(previousAddressBook);
+        previousAddressBook = null;
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -135,6 +135,14 @@ public class AddCommandTest {
         }
 
         @Override
+        public void saveAddressBook() {}
+
+        @Override
+        public void undoAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Allows user to undo the most recent change from commands that modifies the address book (mainly `add`, `delete`, `edit`, `clear`).

Calling undo again right after an undo command will throw error message to result box (don't have time to implement addressBookHistory like the commandHistory). I also don't have redo command (granted, they can literally just scroll up to the past command and just press enter).

Let's say the user successfully enters `delete 1` and then enters `help`, `list`, `find ...`. Then entering `undo` will still work by undoing `delete 1`.