### PR TITLE
Check duplicate prefix for Add command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -16,7 +16,7 @@ public class UndoCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Successfully revert the changes.";
 
-    public static final String MESSAGE_NO_PREVIOUS_STATE = "No new changes has been made to the data.";
+    public static final String MESSAGE_NO_PREVIOUS_STATE = "No new changes have been made to the data.";
 
     @Override
     public CommandResult execute(Model model) throws CommandExecutionException {

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -48,7 +48,9 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_FORCE);
+        argMultimap.verifyNoDuplicatePrefixesFor(
+            PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+            PREFIX_ROLE, PREFIX_ADDRESS, PREFIX_COURSE, PREFIX_FORCE);
 
         boolean shouldCheck = ParserUtil.parseShouldCheckFlag(argMultimap);
 


### PR DESCRIPTION
2 changes.
1) Add command parser now checks for duplicate prefixes for course and role (similar to what edit command parser did).
2) Minor grammar issue with the undo error message.